### PR TITLE
Fix reCAPTCHA site key environment variable prefix

### DIFF
--- a/src/components/Newsletter/Newsletter.js
+++ b/src/components/Newsletter/Newsletter.js
@@ -14,7 +14,7 @@ const Newsletter = () => {
 	const [isFocused, setIsFocused] = useState(false);
 	const reCaptchaRef = useRef(null);
 
-	const siteKey = process.env.RECAPTCHA_SITE_KEY;
+	const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
 
 	const handleChange = (e) => {
 		setEmail(e.target.value);


### PR DESCRIPTION
Updated the Newsletter component to use NEXT_PUBLIC_RECAPTCHA_SITE_KEY instead of RECAPTCHA_SITE_KEY to ensure the reCAPTCHA widget renders correctly on the client side.

Make sure to update the same environment variables to your production environment. 

This change resolves the issue where the reCAPTCHA checkbox was not visible, allowing users to complete the subscription process successfully.