### PR TITLE
Undo banner removal

### DIFF
--- a/src/components/Banner/Banner.js
+++ b/src/components/Banner/Banner.js
@@ -1,0 +1,96 @@
+"use client";
+
+import { useBanner } from "@/context/BannerContext";
+import TertiaryButton from "@/macros/Buttons/TertiaryButton";
+import { useScrollPosition } from "@/utils/scrollLock";
+import { useEffect, useLayoutEffect } from "react";
+
+export default function Banner({ showBanner = true }) {
+	const { isBannerVisible, setIsBannerVisible, bannerRef } = useBanner();
+	const { menuIsOpen } = useScrollPosition();
+
+	// Update banner visibility based on prop
+	useLayoutEffect(() => {
+		setIsBannerVisible(showBanner);
+	}, [showBanner, setIsBannerVisible]);
+
+	if (!isBannerVisible || menuIsOpen) {
+		return null;
+	}
+
+	return (
+		<div className='relative' ref={bannerRef}>
+			{/* Background color */}
+			<div className='absolute inset-0 bg-[#1D013D]' />
+			{/* Background image with opacity */}
+			<div className="absolute inset-0 bg-[url('/images/components/banner/mamothon-image.jpg')] bg-cover bg-center" />
+			{/* Content */}
+			<div className='relative px-3 py-3 sm:px-6 lg:px-8'>
+				<div className='flex flex-col justify-center gap-3 md:flex-row'>
+					<div className='flex justify-between md:items-center'>
+						<div className='flex items-center'>
+							<p className='font-medium text-white'>
+								<span className='sm:hidden'>
+									<span className='mr-4 text-white text-[15px]'>Announcing mamo-1:</span>
+									<br />
+									<span className='text-white mr-2 text-[15px]'>Celestia&apos;s 128MB block testnet</span>
+								</span>
+								<span className='hidden sm:inline'>
+									<span className='text-white'>Announcing mamo-1:</span>{" "}
+									<span className='text-white'>Celestia&apos;s 128MB block testnet</span>
+								</span>
+							</p>
+						</div>
+						<button
+							type='button'
+							className='flex p-2 -mt-1 -mr-1 transition-all duration-200 rounded-md h-fit md:hidden hover:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-white sm:-mr-2'
+							onClick={() => setIsBannerVisible(false)}
+						>
+							<span className='sr-only'>Dismiss</span>
+							<svg
+								className='w-6 h-6 text-white'
+								xmlns='http://www.w3.org/2000/svg'
+								fill='none'
+								viewBox='0 0 24 24'
+								stroke='currentColor'
+							>
+								<path strokeLinecap='round' strokeLinejoin='round' strokeWidth='2' d='M6 18L18 6M6 6l12 12' />
+							</svg>
+						</button>
+					</div>
+					<div className='flex order-3 w-auto gap-4 mt-2 sm:order-2 sm:mt-0 sm:w-auto'>
+						<TertiaryButton href='https://docs.celestia.org/how-to-guides/mammoth' size='md'>
+							<div className='flex items-center justify-center w-full gap-2'>
+								<span className='flex-shrink-0'>Push your stack</span>
+								<svg
+									className='flex-shrink-0 size-2.5 text-black transition-all duration-200 group-hover:text-[#00FFFF]'
+									viewBox='0 0 10 10'
+									fill='none'
+									xmlns='http://www.w3.org/2000/svg'
+								>
+									<path d='M1 1L9 1M9 1V9M9 1L1 9' stroke='currentColor' strokeLinecap='round' strokeLinejoin='round' />
+								</svg>
+							</div>
+						</TertiaryButton>
+						<button
+							type='button'
+							className='absolute flex p-2 -mr-1 transition-all duration-200 transform -translate-y-1/2 rounded-md right-6 top-1/2 h-fit max-md:hidden hover:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-white sm:-mr-2'
+							onClick={() => setIsBannerVisible(false)}
+						>
+							<span className='sr-only'>Dismiss</span>
+							<svg
+								className='w-6 h-6 text-white'
+								xmlns='http://www.w3.org/2000/svg'
+								fill='none'
+								viewBox='0 0 24 24'
+								stroke='currentColor'
+							>
+								<path strokeLinecap='round' strokeLinejoin='round' strokeWidth='2' d='M6 18L18 6M6 6l12 12' />
+							</svg>
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/Banner/Banner.js
+++ b/src/components/Banner/Banner.js
@@ -3,7 +3,7 @@
 import { useBanner } from "@/context/BannerContext";
 import TertiaryButton from "@/macros/Buttons/TertiaryButton";
 import { useScrollPosition } from "@/utils/scrollLock";
-import { useEffect, useLayoutEffect } from "react";
+import { useLayoutEffect } from "react";
 
 export default function Banner({ showBanner = true }) {
 	const { isBannerVisible, setIsBannerVisible, bannerRef } = useBanner();

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -1,5 +1,6 @@
 "use client";
 import Container from "@/components/Container/Container";
+import Banner from "@/components/Banner/Banner"; // Don't delete or comment out, just go to Banner component and switch the showBanner to true/false
 import PrimaryButton from "@/macros/Buttons/PrimaryButton";
 import Icon from "@/macros/Icons/Icon";
 import Link from "@/macros/Link/Link";
@@ -56,6 +57,7 @@ const Nav = () => {
 				ref={primaryNavRef}
 			>
 				{/* Don't delete or comment out, just switch the showBanner to true/false  */}
+				<Banner showBanner={false} />
 
 				<Container size={"lg"} padding={false}>
 					<div


### PR DESCRIPTION
This pull request introduces a new `Banner` component and integrates it into the navigation bar, allowing for a configurable announcement banner at the top of the page. The banner is designed to be easily shown or hidden via a prop, and includes responsive design and dismiss functionality.

**Component Addition and Integration:**

* Added a new `Banner` component in `src/components/Banner/Banner.js`, which displays an announcement with a background image, responsive layout, and dismiss buttons for both mobile and desktop. The banner uses context for visibility state and hides itself when a menu is open.
* Integrated the `Banner` component into the navigation bar by importing it in `src/components/Nav/Nav.js` and rendering it above the main container, with a `showBanner` prop to control its visibility. [[1]](diffhunk://#diff-39b1178d17115a7cc23a48608febf40d0f05ad4fb1d0acaeea095df10d05198fR3) [[2]](diffhunk://#diff-39b1178d17115a7cc23a48608febf40d0f05ad4fb1d0acaeea095df10d05198fR60)