### PR TITLE
chore: update lodash to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4680,9 +4680,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.debounce": {


### PR DESCRIPTION
## Summary
Resolves https://github.com/celestiaorg/celestia.org/security/dependabot?q=is%3Aopen+manifest%3Apackage-lock.json+package%3Alodash
- update the locked transitive `lodash` dependency from `4.17.23` to `4.18.1`
- clear the open `package-lock.json` Dependabot alerts for `lodash`
- avoid broader dependency churn by limiting the change to the lockfile entry

## Verification
- `npm update lodash --package-lock-only --ignore-scripts`
- `npm audit --json` no longer reports a `lodash` vulnerability
- `npm audit --omit=dev --json` no longer reports a `lodash` vulnerability