### PR TITLE
fix(security): bump next to ^15.5.18 to patch high-severity CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"lumina-node": "^0.10.0",
 				"markdown-to-jsx": "^7.4.7",
 				"motion": "^10.18.0",
-				"next": "^15.5.7",
+				"next": "^15.5.18",
 				"next-plausible": "^3.12.4",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
@@ -794,9 +794,9 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "15.5.13",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.13.tgz",
-			"integrity": "sha512-6h7Fm29+/u1WBPcPaQl0xBov7KXB6i0c8oFlSlehD+PuZJQjzXQBuYzfkM32G5iWOlKsXXyRtcMaaqwspRBujA==",
+			"version": "15.5.18",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+			"integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
 			"license": "MIT"
 		},
 		"node_modules/@next/eslint-plugin-next": {
@@ -840,9 +840,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "15.5.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.13.tgz",
-			"integrity": "sha512-XrBbj2iY1mQSsJ8RoFClNpUB9uuZejP94v9pJuSAzdzwFVHeP+Vu2vzBCHwSObozgYNuTVwKhLukG1rGCgj8xA==",
+			"version": "15.5.18",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+			"integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -856,9 +856,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "15.5.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.13.tgz",
-			"integrity": "sha512-Ey3fuUeWDWtVdgiLHajk2aJ74Y8EWLeqvfwlkB5RvWsN7F1caQ6TjifsQzrAcOuNSnogGvFNYzjQlu7tu0kyWg==",
+			"version": "15.5.18",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+			"integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
 			"cpu": [
 				"x64"
 			],
@@ -872,9 +872,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "15.5.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.13.tgz",
-			"integrity": "sha512-aLtu/WxDeL3188qx3zyB3+iw8nAB9F+2Mhyz9nNZpzsREc2t8jQTuiWY4+mtOgWp1d+/Q4eXuy9m3dwh3n1IyQ==",
+			"version": "15.5.18",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+			"integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
 			"cpu": [
 				"arm64"
 			],
@@ -888,9 +888,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "15.5.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.13.tgz",
-			"integrity": "sha512-9VZ0OsVx9PEL72W50QD15iwSCF3GD/dwj42knfF5C4aiBPXr95etGIOGhb8rU7kpnzZuPNL81CY4vIyUKa2xvg==",
+			"version": "15.5.18",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+			"integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
 			"cpu": [
 				"arm64"
 			],
@@ -904,9 +904,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "15.5.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.13.tgz",
-			"integrity": "sha512-3knsu9H33e99ZfiWh0Bb04ymEO7YIiopOpXKX89ZZ/ER0iyfV1YLoJFxJJQNUD7OR8O7D7eiLI/TXPryPGv3+A==",
+			"version": "15.5.18",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+			"integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
 			"cpu": [
 				"x64"
 			],
@@ -920,9 +920,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "15.5.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.13.tgz",
-			"integrity": "sha512-AVPb6+QZ0pPanJFc1hpx81I5tTiBF4VITw5+PMaR1CrboAUUxtxn3IsV0h48xI7fzd6/zw9D9i6khRwME5NKUw==",
+			"version": "15.5.18",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+			"integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
 			"cpu": [
 				"x64"
 			],
@@ -936,9 +936,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "15.5.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.13.tgz",
-			"integrity": "sha512-FZ/HXuTxn+e5Lp6oRZMvHaMJx22gAySveJdJE0//91Nb9rMuh2ftgKlEwBFJxhkw5kAF/yIXz3iBf0tvDXRmCA==",
+			"version": "15.5.18",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+			"integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
 			"cpu": [
 				"arm64"
 			],
@@ -952,9 +952,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "15.5.13",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.13.tgz",
-			"integrity": "sha512-B5E82pX3VXu6Ib5mDuZEqGwT8asocZe3OMMnaM+Yfs0TRlmSQCBQUUXR9BkXQeGVboOWS1pTsRkS9wzFd8PABw==",
+			"version": "15.5.18",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+			"integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
 			"cpu": [
 				"x64"
 			],
@@ -5124,12 +5124,12 @@
 			"peer": true
 		},
 		"node_modules/next": {
-			"version": "15.5.13",
-			"resolved": "https://registry.npmjs.org/next/-/next-15.5.13.tgz",
-			"integrity": "sha512-n0AXf6vlTwGuM93Z++POtjMsRuQ9pT5v2URPciXKUQIl/EB2WjXF0YiIUxaa9AEMFaMpZlaG3KPK6i4UVnx9eQ==",
+			"version": "15.5.18",
+			"resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+			"integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "15.5.13",
+				"@next/env": "15.5.18",
 				"@swc/helpers": "0.5.15",
 				"caniuse-lite": "^1.0.30001579",
 				"postcss": "8.4.31",
@@ -5142,14 +5142,14 @@
 				"node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "15.5.13",
-				"@next/swc-darwin-x64": "15.5.13",
-				"@next/swc-linux-arm64-gnu": "15.5.13",
-				"@next/swc-linux-arm64-musl": "15.5.13",
-				"@next/swc-linux-x64-gnu": "15.5.13",
-				"@next/swc-linux-x64-musl": "15.5.13",
-				"@next/swc-win32-arm64-msvc": "15.5.13",
-				"@next/swc-win32-x64-msvc": "15.5.13",
+				"@next/swc-darwin-arm64": "15.5.18",
+				"@next/swc-darwin-x64": "15.5.18",
+				"@next/swc-linux-arm64-gnu": "15.5.18",
+				"@next/swc-linux-arm64-musl": "15.5.18",
+				"@next/swc-linux-x64-gnu": "15.5.18",
+				"@next/swc-linux-x64-musl": "15.5.18",
+				"@next/swc-win32-arm64-msvc": "15.5.18",
+				"@next/swc-win32-x64-msvc": "15.5.18",
 				"sharp": "^0.34.3"
 			},
 			"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"lumina-node": "^0.10.0",
 		"markdown-to-jsx": "^7.4.7",
 		"motion": "^10.18.0",
-		"next": "^15.5.7",
+		"next": "^15.5.18",
 		"next-plausible": "^3.12.4",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",


### PR DESCRIPTION
## Summary
- Bumps `next` from `^15.5.7` to `^15.5.18` (lockfile resolves to 15.5.18) to resolve 5 open Dependabot alerts.
- No source changes — patch-level dependency update only. Production build verified.

## Vulnerabilities resolved
| # | Severity | Summary | Fixed in |
|---|----------|---------|----------|
| [99](https://github.com/celestiaorg/celestia.org/security/dependabot/99) | High | DoS via connection exhaustion in apps using Cache Components | 15.5.16 |
| [98](https://github.com/celestiaorg/celestia.org/security/dependabot/98) | High | Middleware / Proxy bypass via segment-prefetch routes | 15.5.16 |
| [97](https://github.com/celestiaorg/celestia.org/security/dependabot/97) | High | Middleware / Proxy bypass via segment-prefetch routes (incomplete-fix follow-up) | 15.5.18 |
| [96](https://github.com/celestiaorg/celestia.org/security/dependabot/96) | High | Middleware / Proxy bypass via dynamic route parameter injection | 15.5.16 |
| [67](https://github.com/celestiaorg/celestia.org/security/dependabot/67) | Medium | Unbounded `next/image` disk cache growth can exhaust storage | 15.5.14 |

Targeting `15.5.18` (rather than `15.5.16`) covers the incomplete-fix follow-up advisory while staying on the same minor.

## Test plan
- [x] `npm install` clean
- [x] `npm run build` succeeds (all routes still generate)
- [ ] Smoke-check key pages on preview deploy (home, ecosystem, learn, glossary)
- [ ] Confirm Dependabot closes alerts 67, 96, 97, 98, 99 once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)