### PR TITLE
feat(api): add /api/health endpoint for K8s liveness/readiness probes

### DIFF
--- a/src/app/api/health/route.js
+++ b/src/app/api/health/route.js
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Health check endpoint for Kubernetes liveness/readiness probes.
+ *
+ * Why this exists: probes previously hit static assets (/favicon.ico, then
+ * /robots.txt). Static files are served straight from disk and stay "200 OK"
+ * even if the Node runtime is wedged — a false healthy. This route is rendered
+ * dynamically, so a 200 here confirms the Next.js server is actually accepting
+ * and serving requests.
+ *
+ * It is intentionally lightweight: no env reads, no external calls, no DB
+ * lookups — so it cannot time out or fail for the wrong reason. This is a
+ * liveness signal, not a deep dependency check.
+ *
+ * NOTE FOR INFRA: this app sets `trailingSlash: true` (next.config.js), so the
+ * canonical path is `/api/health/`. Hitting `/api/health` (no slash) returns a
+ * 308 redirect to `/api/health/`. Point the K8s probe `path` at `/api/health/`
+ * to get a clean, direct 200.
+ */
+
+// Always run through the runtime — never statically optimized or cached.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const HEALTH_HEADERS = {
+	"Cache-Control": "no-store, no-cache, must-revalidate",
+};
+
+export async function GET() {
+	return NextResponse.json({ status: "ok" }, { status: 200, headers: HEALTH_HEADERS });
+}
+
+// Some probe configurations issue HEAD requests — answer cheaply with no body.
+export async function HEAD() {
+	return new Response(null, { status: 200, headers: HEALTH_HEADERS });
+}


### PR DESCRIPTION
Closes #163

## What

Adds `src/app/api/health/route.js` — a lightweight, dynamically-rendered health endpoint for Kubernetes liveness/readiness probes.

- `GET /api/health/` → `200 { "status": "ok" }`, `Cache-Control: no-store`
- `HEAD /api/health/` → `200` (no body) — for probe configs that use HEAD
- `export const dynamic = "force-dynamic"` so it always runs through the runtime
- No env reads, no network/DB calls → it cannot time out or fail for the wrong reason

## Why

Per #163: probes were hitting `/favicon.ico` (dynamically generated in Next 13+ → timeouts), then temporarily `/robots.txt` (PR #200). Static assets stay `200 OK` even when the Node runtime is wedged — a false healthy. This route is rendered dynamically, so a `200` confirms the Next.js server is actually accepting and serving requests, as Jose requested.

## ⚠️ Probe path: use the trailing slash

This app sets `trailingSlash: true` in `next.config.js`, so the canonical path is **`/api/health/`**. Hitting `/api/health` (no slash) returns a `308` redirect to `/api/health/`. kubelet treats `3xx` as success so it won't break, but point the probe `path` at `/api/health/` for a clean direct `200`.

Suggested probe config (to replace the `/robots.txt` band-aid):

\`\`\`yaml
livenessProbe:
  httpGet:
    path: /api/health/
    port: 3000
  timeoutSeconds: 3
  periodSeconds: 10
readinessProbe:
  httpGet:
    path: /api/health/
    port: 3000
  timeoutSeconds: 3
  periodSeconds: 10
\`\`\`

## Verification

Tested against `npm run dev`:

| Request | Result |
|---|---|
| `GET /api/health/` | `200` `{"status":"ok"}`, `Cache-Control: no-store` |
| `GET /api/health` | `308` → `/api/health/` |
| `HEAD /api/health/` | `200`, no body |

`npm run lint` clean. One new file; nothing else touched.