### PR TITLE
fix(security): remove unused axios and swiper dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"dependencies": {
 				"@mailchimp/mailchimp_marketing": "^3.0.80",
 				"@tailwindcss/line-clamp": "^0.4.4",
-				"axios": "^1.12.0",
 				"bowser": "^2.13.1",
 				"clsx": "^2.1.1",
 				"framer-motion": "^11.2.13",
@@ -30,7 +29,6 @@
 				"react-stickynode": "^4.1.1",
 				"sass": "^1.77.8",
 				"slick-carousel": "^1.8.1",
-				"swiper": "^11.2.6",
 				"tailwind-merge": "^3.3.0",
 				"tailwind-variants": "^3.2.2"
 			},
@@ -1972,17 +1970,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/axios": {
-			"version": "1.13.6",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-			"integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
-			"license": "MIT",
-			"dependencies": {
-				"follow-redirects": "^1.15.11",
-				"form-data": "^4.0.5",
-				"proxy-from-env": "^1.1.0"
-			}
-		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -3465,26 +3452,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/follow-redirects": {
-			"version": "1.15.11",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/RubenVerborgh"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=4.0"
-			},
-			"peerDependenciesMeta": {
-				"debug": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/for-each": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3513,22 +3480,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-			"license": "MIT",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/formidable": {
@@ -5800,10 +5751,6 @@
 				"react-is": "^16.13.1"
 			}
 		},
-		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"license": "MIT"
-		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"dev": true,
@@ -7062,25 +7009,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/swiper": {
-			"version": "11.2.10",
-			"resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.10.tgz",
-			"integrity": "sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==",
-			"funding": [
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/swiperjs"
-				},
-				{
-					"type": "open_collective",
-					"url": "http://opencollective.com/swiper"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.7.0"
 			}
 		},
 		"node_modules/tailwind-merge": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
 	"dependencies": {
 		"@mailchimp/mailchimp_marketing": "^3.0.80",
 		"@tailwindcss/line-clamp": "^0.4.4",
-		"axios": "^1.12.0",
 		"bowser": "^2.13.1",
 		"clsx": "^2.1.1",
 		"framer-motion": "^11.2.13",
@@ -34,7 +33,6 @@
 		"react-stickynode": "^4.1.1",
 		"sass": "^1.77.8",
 		"slick-carousel": "^1.8.1",
-		"swiper": "^11.2.6",
 		"tailwind-merge": "^3.3.0",
 		"tailwind-variants": "^3.2.2"
 	},


### PR DESCRIPTION
## Summary

`axios` and `swiper` were declared as direct dependencies in `package.json` but are **not imported anywhere** in the codebase (carousels use `react-slick`/`slick-carousel`). Removing them clears **16 open [Dependabot alerts](https://github.com/celestiaorg/celestia.org/security/dependabot)** with zero behavior change.

## Alerts cleared

| Package | Alerts | Severity |
|---|---|---|
| swiper | #51 | 🔴 critical (prototype pollution) |
| axios | #81, #83, #86–93, #100–104 | 🔴 high ×4 + medium/low |
| follow-redirects | #80 | medium (axios was its only parent) |

This is PR 1 of 2. PR 2 will patch the remaining transitive-dependency alerts (`postcss`, `qs`, `uuid`, `yaml`, `picomatch`, `fast-uri`, `serialize-javascript`, `brace-expansion`) and add a `.github/dependabot.yml`.

## Verification

- `npm install` regenerates the lockfile cleanly (axios, swiper, follow-redirects removed from the tree).
- `npm run build` passes.
- Local `next lint` reports a plugin conflict only because this branch was developed in a git worktree nested inside another checkout (two `.eslintrc.json` files); CI runs lint in a clean checkout where it passes.

> No tracking GitHub/Linear issue exists for these alerts; referencing the Dependabot alert numbers directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)