### PR TITLE
ci: auto-purge Cloudflare cache after each deploy

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -40,3 +40,10 @@ jobs:
           run: |
             docker build --build-arg NEXT_PUBLIC_GHOST_API_URL=$NEXT_PUBLIC_GHOST_API_URL --build-arg NEXT_PUBLIC_GHOST_CONTENT_API_KEY=$NEXT_PUBLIC_GHOST_CONTENT_API_KEY --build-arg MAILCHIMP_API_KEY=$MAILCHIMP_API_KEY --build-arg MAILCHIMP_LIST_ID=$MAILCHIMP_LIST_ID --build-arg MAILCHIMP_SERVER_PREFIX=$MAILCHIMP_SERVER_PREFIX --build-arg NEXT_PUBLIC_RECAPTCHA_SITE_KEY=$NEXT_PUBLIC_RECAPTCHA_SITE_KEY --build-arg RECAPTCHA_SECRET_KEY=$RECAPTCHA_SECRET_KEY --build-arg NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL --build-arg ENV_MODE=$ENV_MODE -t ghcr.io/celestiaorg/celestia.org:latest .
             docker push ghcr.io/celestiaorg/celestia.org:latest
+
+        - name: Purge Cloudflare cache
+          run: |
+            curl -s -X POST "https://api.cloudflare.com/client/v4/zones/dfbcbc30a0faf336d6fb18fb79ffd04e/purge_cache" \
+              -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+              -H "Content-Type: application/json" \
+              --data '{"purge_everything":true}'


### PR DESCRIPTION
## Summary

- Adds a **Purge Cloudflare cache** step at the end of the Docker Build and Publish workflow
- Runs automatically after every successful image push to `ghcr.io`
- Uses `CLOUDFLARE_API_TOKEN` GitHub secret (zone: `celestia.org`) to call the CF purge API

## Why

Every merged PR that changes JS/CSS/asset files generates new `_next/static` hashes. Without a purge, Cloudflare edge PoPs serve stale 404s for the new hashes, causing blank/broken pages until the cache naturally expires. This automates what was previously a manual step after each deploy.