### PR TITLE
docs: document PR review expectations and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# CODEOWNERS — GitHub auto-requests a review from the listed owners when a PR
+# touches a matching path. Last matching pattern wins. See the "PR review
+# expectations" section in README.md for the rationale.
+
+# Default owners for everything not matched below (app/site code).
+*                   @renaynay @pippokr
+
+# Content changes → Marketing review.
+/src/data/          @damilico
+/src/content/       @damilico
+/public/            @damilico
+
+# Infrastructure, tooling, and dependency changes → DevOps review.
+/.github/           @pippokr
+/.husky/            @pippokr
+/scripts/           @pippokr
+/Dockerfile         @pippokr
+/.dockerignore      @pippokr
+/.nvmrc             @pippokr
+/package.json       @pippokr
+/package-lock.json  @pippokr
+/next.config.js     @pippokr
+/tailwind.config.js @pippokr
+/postcss.config.mjs @pippokr
+/eslint.config.mjs  @pippokr
+/tsconfig.json      @pippokr

--- a/README.md
+++ b/README.md
@@ -144,3 +144,13 @@ changes locally with `docker build .`. A second workflow (`link-checker.yml`) cr
 Branch from `main` (`feature/…`, `fix/…`, `chore/…`), write
 [Conventional Commits](https://www.conventionalcommits.org/), and open a PR into `main`. Make sure
 `npm run verify` passes. Full details in [ONBOARDING.md](./ONBOARDING.md).
+
+## PR review expectations
+
+Who reviews your PR depends on what it changes. [`.github/CODEOWNERS`](./.github/CODEOWNERS)
+auto-requests the right people:
+
+- **DevOps** (Cris, [@pippokr](https://github.com/pippokr)) reviews infrastructure, tooling, and
+  dependency changes.
+- **Marketing** (Damilico, [@damilico](https://github.com/damilico), or Sandy) reviews content
+  changes.


### PR DESCRIPTION
Motivation: https://celestia-team.slack.com/archives/C03324EKQ1Y/p1782831021070539?thread_ts=1782414372.750159&cid=C03324EKQ1Y

Adds a **PR review expectations** section to the README and a `.github/CODEOWNERS` file so GitHub auto-requests the right reviewers.

- **DevOps** (Cris, @pippokr) — infrastructure, tooling, dependency changes.
- **Marketing** (@damilico, or Sandy) — content changes.
- General app/site code defaults to @renaynay + @pippokr.

CODEOWNERS encodes this split by path (content → Marketing, infra/tooling/deps → DevOps). Sandy is mentioned in the README but omitted from CODEOWNERS pending a GitHub handle.

Motivation: make review ownership explicit so contributors know who to expect review from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)