### PR TITLE
content(homepage): align TPS claims with benchmarks blog (625M, not 1B)

### DIFF
--- a/src/components/NewHomepage/BenefitsSection.tsx
+++ b/src/components/NewHomepage/BenefitsSection.tsx
@@ -34,7 +34,7 @@ const benefits = [
 			</>
 		),
 		description:
-			"Unlike legacy blockchains, Celestia separates compute and storage so each can scale independently. We built Fibre to accommodate 1 Tb/s of data throughput (~1B+ transactions per second), so you can move your business onto blockchain rails, no matter how ambitious your vision.",
+			"Unlike legacy blockchains, Celestia separates compute and storage so each can scale independently. We built Fibre to accommodate 1 Tb/s of data throughput (~625M transactions per second), so you can move your business onto blockchain rails, no matter how ambitious your vision.",
 		mp4: "/videos/benefit-1-v3.mp4",
 	},
 	{

--- a/src/components/NewHomepage/ProofPoints.tsx
+++ b/src/components/NewHomepage/ProofPoints.tsx
@@ -9,7 +9,7 @@ const stats = [
 		label: "Production chains built and launched by the team.",
 	},
 	{
-		number: "1B+",
+		number: "600M+ TPS",
 		label: "Potential throughput of blockchains built on Celestia.",
 	},
 	{

--- a/src/components/NewHomepage/UseCasesSection.tsx
+++ b/src/components/NewHomepage/UseCasesSection.tsx
@@ -92,7 +92,7 @@ const AgenticVisual = () => (
 	<div className='flex flex-col justify-start gap-4 px-6 md:px-8 pb-7 flex-1 max-md:min-h-[200px]'>
 		{/* Answer headline — a small lead line over an oversized figure
 		    (prototype revision): regular-weight steel-blue lede, then a large
-		    NuberNext Wide "1.25B TPS" numeral. */}
+		    NuberNext Wide "625M TPS" numeral. */}
 		<div className='flex flex-col gap-1.5 m-0'>
 			<span
 				className='font-nuberNext font-medium text-[17px] min-[431px]:text-[18px] md:text-[20px] leading-[1.3] tracking-[-0.02em]'
@@ -104,7 +104,7 @@ const AgenticVisual = () => (
 				className='font-nuberNextWide font-semibold text-[40px] min-[431px]:text-[46px] md:text-[56px] leading-[1.0] tracking-[-0.03em]'
 				style={{ color: STEEL_BLUE }}
 			>
-				1.25B TPS
+				625M TPS
 			</span>
 		</div>
 
@@ -269,7 +269,7 @@ const UseCasesSection = () => {
 									Agentic Payments
 								</h3>
 								<span className='block font-nuberNextWide font-medium text-[23px] min-[431px]:text-[26px] md:text-[32px] leading-[1.18] md:leading-[1.25] tracking-[-0.025em] text-[#1a1a1a] mb-4'>
-									1B+ Payments / Second
+									625M Payments / Second
 								</span>
 								<p className='font-nuberNext text-[16px] leading-[1.5] tracking-[-0.01em] text-[#4a4a5a]'>
 									AI agents will transact at a frequency no legacy blockchain can support. We build rails so enterprises serving agents can monetise every agentic action in its ecosystem.

--- a/src/data/about/team.ts
+++ b/src/data/about/team.ts
@@ -6,7 +6,7 @@ export const aboutStats = [
 		label: "Production chains built and launched by the team.",
 	},
 	{
-		number: "1B+",
+		number: "600M+ TPS",
 		label: "Potential throughput of blockchains built on Celestia.",
 	},
 	{

--- a/src/data/applications/content.ts
+++ b/src/data/applications/content.ts
@@ -10,7 +10,7 @@ export const tabs = [
 export const hero = {
   eyebrow: "Applications",
   heading: "Every API call paid, every order processed, every market verifiable.",
-  subtitle: "1B+ transactions per second\nto meet that demand.",
+  subtitle: "625M transactions per second\nto meet that demand.",
   cta: { label: "Explore Agentic Payments", href: "#agentic-use-cases" },
 };
 
@@ -52,7 +52,7 @@ export const panels = {
           "Existing chains handle simple agent-pays-once flows.",
           "Continuous autonomous micropayments (where every API call, crawl, and inference triggers a settlement) break them. AI agents need millions of TPS as baseline load.",
         ],
-        accentBody: "Celestia Fibre delivers 250M to 1.25B TPS at micropayment sizes.",
+        accentBody: "Celestia Fibre delivers up to 625M TPS at micropayment sizes.",
       },
       {
         number: "03",
@@ -143,7 +143,7 @@ export const whyCelestia = {
   agentic: {
     title: "Why Celestia for agentic payments?",
     points: [
-      { bold: "Throughput.", description: "1 Tb/s via Fibre — 250M to 1.25B TPS at micropayment sizes. The only infrastructure in the throughput class this economy demands." },
+      { bold: "Throughput.", description: "1 Tb/s via Fibre — up to 625M TPS at micropayment sizes. The only infrastructure in the throughput class this economy demands." },
       { bold: "Fee capture.", description: "Sovereign chains on Celestia keep their sequencer revenue. At 100M TPS and $0.0001/tx, that could be up to ~$3.15B/year in fee revenue that stays with you." },
       { bold: "Sub-millisecond settlement.", description: "Sovereign chains on Celestia can achieve sequencer-level confirmations in under a millisecond. Agent micropayments settle at HTTP speed, so the payment never becomes the bottleneck." },
     ],


### PR DESCRIPTION
## What
Aligns every public TPS/throughput claim on the site to the source-of-truth figure, replacing the rounded-up `1B+` / `1.25B` numbers with **625M** (the homepage hero stat uses `600M+ TPS`).

## Why
Per review feedback, our TPS claims should match the benchmarks blog. [Why blockchain benchmarks are usually deceiving](https://blog.celestia.org/why-blockchain-benchmarks-are-usually-deceiving/) states in its DA section:

> "Celestia Fibre, which implements ZODA, can support up to 1Tb/s of DA or **~625M TPS**" (assuming 200-byte transactions).

The site was rounding this up to `1B+` and quoting a `1.25B` upper bound that exceeds the blog's stated ceiling.

## Changes
| Location | Before | After |
|---|---|---|
| Homepage & About proof-point stat | `1B+` | `600M+ TPS` |
| Homepage Agentic card | `1B+ Payments / Second`, `1.25B TPS` | `625M Payments / Second`, `625M TPS` |
| Homepage "Throughput" benefit | `~1B+ transactions per second` | `~625M transactions per second` |
| Applications hero | `1B+ transactions per second` | `625M transactions per second` |
| Applications agentic panels | `250M to 1.25B TPS` | `up to 625M TPS` |

The Cloudflare CEO tweet quote ("1B microtransactions per second") is **left verbatim** — it's a third-party quotation, not our claim.

## Preview
Live preview of this branch (temporary, self-terminates in ~2 days): http://3.149.231.175/

## Notes
- Copy-only change across 5 files; no logic touched.
- `npm run verify` (lint + typecheck + build) passes locally and in the pre-push hook.