### PR TITLE
Copy updates: TPS figures, proof points, production chains, leadership

### DIFF
--- a/src/app/(default)/about/page.tsx
+++ b/src/app/(default)/about/page.tsx
@@ -8,7 +8,7 @@ import AboutCTA from "@/components/NewPages/About/AboutCTA";
 const seo = {
 	title: "About",
 	description:
-		"Celestia builds dedicated, high-throughput chains for companies with internet-scale traffic. Meet the team behind the frameworks powering 100+ production chains.",
+		"Celestia builds dedicated, high-throughput chains for companies with internet-scale traffic. Meet the team behind the frameworks powering 25+ production chains.",
 	canonical: "https://celestia.org/about/",
 };
 

--- a/src/components/NewHomepage/BenefitsSection.tsx
+++ b/src/components/NewHomepage/BenefitsSection.tsx
@@ -34,7 +34,7 @@ const benefits = [
 			</>
 		),
 		description:
-			"Unlike legacy blockchains, Celestia separates compute and storage so each can scale independently. We built Fibre to accommodate 1 Tb/s of data throughput (~625M transactions per second), so you can move your business onto blockchain rails, no matter how ambitious your vision.",
+			"Unlike legacy blockchains, Celestia separates compute and storage so each can scale independently. We built Fibre to accommodate 1 Tb/s of data throughput (10M+ transactions per second), so you can move your business onto blockchain rails, no matter how ambitious your vision.",
 		mp4: "/videos/benefit-1-v3.mp4",
 	},
 	{

--- a/src/components/NewHomepage/ProofPoints.tsx
+++ b/src/components/NewHomepage/ProofPoints.tsx
@@ -46,7 +46,7 @@ const ProofPoints = () => {
 								<span className="flex items-center justify-center min-h-[56px] whitespace-nowrap font-nuberNextWide font-semibold text-[32px] min-[900px]:text-[56px] leading-none tracking-[-0.02em] text-[#FDFCFF]">
 									{stat.number}
 								</span>
-								<span className="font-nuberNext font-normal text-[16px] leading-[1.5] tracking-[-0.01em] text-[#B0B7C0] max-w-[280px]">
+								<span className="font-nuberNext font-normal text-[16px] leading-[1.5] tracking-[-0.01em] text-[#E8EBEF] max-w-[280px]">
 									{stat.label}
 								</span>
 							</div>

--- a/src/components/NewHomepage/ProofPoints.tsx
+++ b/src/components/NewHomepage/ProofPoints.tsx
@@ -9,7 +9,7 @@ const stats = [
 		label: "Production chains built and launched by the team.",
 	},
 	{
-		number: "600M+ TPS",
+		number: "10M+ TPS",
 		label: "Potential throughput of blockchains built on Celestia.",
 	},
 	{

--- a/src/components/NewHomepage/TeamSection.tsx
+++ b/src/components/NewHomepage/TeamSection.tsx
@@ -39,13 +39,8 @@ const team = [
 	},
 	{
 		name: "Preston Evans",
-		role: "Chief Solutions Architect, Celestia Labs",
-		bio: "Built the Sovereign SDK, the highest-performance blockchain framework in production.",
-	},
-	{
-		name: "Ismail Khoffi",
 		role: "CTO, Celestia Labs",
-		bio: "Worked at EPFL's Decentralized and Distributed Systems Laboratory and contributed to Tendermint (now CometBFT), one of the first Proof-of-Stake stacks underpinning 200+ production blockchains.",
+		bio: "Built the Sovereign SDK, the highest-performance blockchain framework in production.",
 	},
 ];
 
@@ -56,31 +51,32 @@ interface TeamCardProps {
 }
 
 const TeamCard = ({ name, role, bio }: TeamCardProps) => (
+	// Subgrid (≥900px): name/role and divider+bio sit on rows shared by all
+	// three cards, so the divider lines up across the row regardless of how
+	// long each name, role, or bio is. Below 900px cards stack as plain flex.
 	<motion.div
 		variants={cardVariants}
-		className="group flex bg-transparent border border-white/[0.07] rounded-lg overflow-hidden transition-[background-color,border-color] duration-[350ms] hover:bg-white hover:border-white/[0.13]"
+		className="group flex flex-col gap-2.5 min-w-0 py-5 px-[22px] bg-transparent border border-white/[0.07] rounded-lg overflow-hidden transition-[background-color,border-color] duration-[350ms] hover:bg-white hover:border-white/[0.13] min-[900px]:grid min-[900px]:grid-rows-subgrid min-[900px]:row-span-2"
 	>
-		<div className="flex flex-col justify-between gap-2.5 flex-1 min-w-0 py-5 px-[22px]">
-			<div className="flex flex-col gap-1">
-				<h3 className="font-nuberNextWide font-medium text-[20px] min-[431px]:text-[21px] md:text-[24px] leading-[1.25] tracking-[-0.025em] text-[#FDFCFF] transition-colors duration-[350ms] group-hover:text-[#040207]">
-					{name}
-				</h3>
-				<span className="font-nuberNext text-[16px] leading-[1.4] tracking-[-0.01em] text-white/50 transition-colors duration-[350ms] group-hover:text-[#5a5a5a]">
-					{role}
-				</span>
-			</div>
-			<div className="border-t border-white/[0.07] pt-2.5 transition-colors duration-[350ms] group-hover:border-black/10">
-				<p className="font-nuberNext text-[16px] leading-[1.5] tracking-[-0.01em] text-[#B0B7C0] transition-colors duration-[350ms] group-hover:text-[#5a5a5a]">
-					{bio}
-				</p>
-			</div>
+		<div className="flex flex-col gap-1">
+			<h3 className="font-nuberNextWide font-medium text-[20px] min-[431px]:text-[21px] md:text-[24px] leading-[1.25] tracking-[-0.025em] text-[#FDFCFF] transition-colors duration-[350ms] group-hover:text-[#040207]">
+				{name}
+			</h3>
+			<span className="font-nuberNext text-[16px] leading-[1.4] tracking-[-0.01em] text-white/50 transition-colors duration-[350ms] group-hover:text-[#5a5a5a]">
+				{role}
+			</span>
+		</div>
+		<div className="border-t border-white/[0.07] pt-2.5 transition-colors duration-[350ms] group-hover:border-black/10">
+			<p className="font-nuberNext text-[16px] leading-[1.5] tracking-[-0.01em] text-[#B0B7C0] transition-colors duration-[350ms] group-hover:text-[#5a5a5a]">
+				{bio}
+			</p>
 		</div>
 	</motion.div>
 );
 
 /**
  * TeamSection — "The team that built the frameworks behind 25+ production
- * chains." Ported from the prototype's .home-team section: a 2-column grid of
+ * chains." Ported from the prototype's .home-team section: a 3-column grid of
  * text-only member cards (dark→light on hover) and a "Meet the full team" CTA.
  */
 const TeamSection = () => {
@@ -98,7 +94,7 @@ const TeamSection = () => {
 			</motion.h2>
 
 			<motion.div
-				className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-5 w-full"
+				className="grid grid-cols-1 min-[900px]:grid-cols-3 gap-6 md:gap-5 w-full"
 				initial="hidden"
 				whileInView="visible"
 				viewport={{ once: true, margin: "-50px" }}

--- a/src/components/NewHomepage/TeamSection.tsx
+++ b/src/components/NewHomepage/TeamSection.tsx
@@ -79,7 +79,7 @@ const TeamCard = ({ name, role, bio }: TeamCardProps) => (
 );
 
 /**
- * TeamSection — "The team that built the frameworks behind 100+ production
+ * TeamSection — "The team that built the frameworks behind 25+ production
  * chains." Ported from the prototype's .home-team section: a 2-column grid of
  * text-only member cards (dark→light on hover) and a "Meet the full team" CTA.
  */
@@ -94,7 +94,7 @@ const TeamSection = () => {
 				viewport={{ once: true, margin: "-50px" }}
 				variants={fadeUp}
 			>
-				The team that built the frameworks behind 100+ production chains.
+				The team that built the frameworks behind 25+ production chains.
 			</motion.h2>
 
 			<motion.div

--- a/src/components/NewHomepage/UseCasesSection.tsx
+++ b/src/components/NewHomepage/UseCasesSection.tsx
@@ -92,7 +92,7 @@ const AgenticVisual = () => (
 	<div className='flex flex-col justify-start gap-4 px-6 md:px-8 pb-7 flex-1 max-md:min-h-[200px]'>
 		{/* Answer headline — a small lead line over an oversized figure
 		    (prototype revision): regular-weight steel-blue lede, then a large
-		    NuberNext Wide "625M TPS" numeral. */}
+		    NuberNext Wide "10M+ TPS" numeral. */}
 		<div className='flex flex-col gap-1.5 m-0'>
 			<span
 				className='font-nuberNext font-medium text-[17px] min-[431px]:text-[18px] md:text-[20px] leading-[1.3] tracking-[-0.02em]'
@@ -104,7 +104,7 @@ const AgenticVisual = () => (
 				className='font-nuberNextWide font-semibold text-[40px] min-[431px]:text-[46px] md:text-[56px] leading-[1.0] tracking-[-0.03em]'
 				style={{ color: STEEL_BLUE }}
 			>
-				625M TPS
+				10M+ TPS
 			</span>
 		</div>
 
@@ -269,7 +269,7 @@ const UseCasesSection = () => {
 									Agentic Payments
 								</h3>
 								<span className='block font-nuberNextWide font-medium text-[23px] min-[431px]:text-[26px] md:text-[32px] leading-[1.18] md:leading-[1.25] tracking-[-0.025em] text-[#1a1a1a] mb-4'>
-									625M Payments / Second
+									10M+ Payments / Second
 								</span>
 								<p className='font-nuberNext text-[16px] leading-[1.5] tracking-[-0.01em] text-[#4a4a5a]'>
 									AI agents will transact at a frequency no legacy blockchain can support. We build rails so enterprises serving agents can monetise every agentic action in its ecosystem.

--- a/src/components/NewPages/About/AboutLeadership.tsx
+++ b/src/components/NewPages/About/AboutLeadership.tsx
@@ -25,30 +25,31 @@ interface LeadershipCardProps {
 }
 
 const LeadershipCard = ({ name, role, bio }: LeadershipCardProps) => (
+	// Subgrid (≥900px): name/role and divider+bio sit on rows shared by all
+	// three cards, so the divider lines up across the row regardless of how
+	// long each name, role, or bio is. Below 900px cards stack as plain flex.
 	<motion.div
 		variants={cardVariants}
-		className='group flex overflow-hidden rounded-lg border border-white/[0.07] bg-transparent transition-[background-color,border-color] duration-[350ms] hover:border-white/[0.13] hover:bg-white'
+		className='group flex flex-col gap-2.5 min-w-0 px-[22px] py-5 overflow-hidden rounded-lg border border-white/[0.07] bg-transparent transition-[background-color,border-color] duration-[350ms] hover:border-white/[0.13] hover:bg-white min-[900px]:grid min-[900px]:grid-rows-subgrid min-[900px]:row-span-2'
 	>
-		<div className='flex min-w-0 flex-1 flex-col justify-between gap-2.5 px-[22px] py-5'>
-			<div className='flex flex-col gap-1'>
-				<h3 className='font-nuberNextWide text-[20px] min-[431px]:text-[21px] md:text-[24px] font-medium leading-[1.25] tracking-[-0.025em] text-[#FDFCFF] transition-colors duration-[350ms] group-hover:text-[#040207]'>
-					{name}
-				</h3>
-				<span className='font-nuberNext text-[16px] leading-[1.4] tracking-[-0.01em] text-white/50 transition-colors duration-[350ms] group-hover:text-[#5a5a5a]'>
-					{role}
-				</span>
-			</div>
-			<div className='border-t border-white/[0.07] pt-2.5 transition-colors duration-[350ms] group-hover:border-black/10'>
-				<p className='font-nuberNext text-[16px] leading-[1.5] tracking-[-0.01em] text-[#B0B7C0] transition-colors duration-[350ms] group-hover:text-[#5a5a5a]'>
-					{bio}
-				</p>
-			</div>
+		<div className='flex flex-col gap-1'>
+			<h3 className='font-nuberNextWide text-[20px] min-[431px]:text-[21px] md:text-[24px] font-medium leading-[1.25] tracking-[-0.025em] text-[#FDFCFF] transition-colors duration-[350ms] group-hover:text-[#040207]'>
+				{name}
+			</h3>
+			<span className='font-nuberNext text-[16px] leading-[1.4] tracking-[-0.01em] text-white/50 transition-colors duration-[350ms] group-hover:text-[#5a5a5a]'>
+				{role}
+			</span>
+		</div>
+		<div className='border-t border-white/[0.07] pt-2.5 transition-colors duration-[350ms] group-hover:border-black/10'>
+			<p className='font-nuberNext text-[16px] leading-[1.5] tracking-[-0.01em] text-[#B0B7C0] transition-colors duration-[350ms] group-hover:text-[#5a5a5a]'>
+				{bio}
+			</p>
 		</div>
 	</motion.div>
 );
 
 /**
- * AboutLeadership — dark section listing the four leaders in a 2-column grid
+ * AboutLeadership — dark section listing the three leaders in a 3-column grid
  * (ported from prototype .about-leadership). Cards invert dark→light on hover.
  */
 const AboutLeadership = () => {
@@ -69,7 +70,7 @@ const AboutLeadership = () => {
 					Leadership
 				</motion.h2>
 				<motion.div
-					className='grid grid-cols-1 gap-5 md:grid-cols-2'
+					className='grid grid-cols-1 gap-5 min-[900px]:grid-cols-3'
 					initial='hidden'
 					whileInView='visible'
 					viewport={{ once: true, margin: "-60px" }}

--- a/src/data/about/team.ts
+++ b/src/data/about/team.ts
@@ -6,7 +6,7 @@ export const aboutStats = [
 		label: "Production chains built and launched by the team.",
 	},
 	{
-		number: "600M+ TPS",
+		number: "10M+ TPS",
 		label: "Potential throughput of blockchains built on Celestia.",
 	},
 	{

--- a/src/data/about/team.ts
+++ b/src/data/about/team.ts
@@ -18,7 +18,7 @@ export const aboutStats = [
 export const leadership = [
 	{
 		name: "Mustafa Al-Bassam",
-		role: "Co-founder, Celestia Labs; Chairman, Celestia Foundation",
+		role: "Chairman & CEO, Celestia Foundation",
 		bio: "Co-authored blockchain scaling research with Vitalik Buterin and founded Chainspace, which was acquired by Facebook.",
 	},
 	{
@@ -28,13 +28,8 @@ export const leadership = [
 	},
 	{
 		name: "Preston Evans",
-		role: "Chief Solutions Architect, Celestia Labs",
+		role: "CTO, Celestia Labs",
 		bio: "Built the Sovereign SDK, the highest-performance blockchain framework in production.",
-	},
-	{
-		name: "Ismail Khoffi",
-		role: "Co-founder & CTO, Celestia Labs",
-		bio: "Worked at EPFL's Decentralized and Distributed Systems Laboratory and contributed to Tendermint (now CometBFT), one of the first Proof-of-Stake stacks underpinning 200+ production blockchains.",
 	},
 ];
 

--- a/src/data/applications/content.ts
+++ b/src/data/applications/content.ts
@@ -10,7 +10,7 @@ export const tabs = [
 export const hero = {
   eyebrow: "Applications",
   heading: "Every API call paid, every order processed, every market verifiable.",
-  subtitle: "625M transactions per second\nto meet that demand.",
+  subtitle: "10M+ transactions per second\nto meet that demand.",
   cta: { label: "Explore Agentic Payments", href: "#agentic-use-cases" },
 };
 
@@ -52,7 +52,7 @@ export const panels = {
           "Existing chains handle simple agent-pays-once flows.",
           "Continuous autonomous micropayments (where every API call, crawl, and inference triggers a settlement) break them. AI agents need millions of TPS as baseline load.",
         ],
-        accentBody: "Celestia Fibre delivers up to 625M TPS at micropayment sizes.",
+        accentBody: "Celestia Fibre delivers up to 10M+ TPS at micropayment sizes.",
       },
       {
         number: "03",
@@ -143,7 +143,7 @@ export const whyCelestia = {
   agentic: {
     title: "Why Celestia for agentic payments?",
     points: [
-      { bold: "Throughput.", description: "1 Tb/s via Fibre — up to 625M TPS at micropayment sizes. The only infrastructure in the throughput class this economy demands." },
+      { bold: "Throughput.", description: "1 Tb/s via Fibre — up to 10M+ TPS at micropayment sizes. The only infrastructure in the throughput class this economy demands." },
       { bold: "Fee capture.", description: "Sovereign chains on Celestia keep their sequencer revenue. At 100M TPS and $0.0001/tx, that could be up to ~$3.15B/year in fee revenue that stays with you." },
       { bold: "Sub-millisecond settlement.", description: "Sovereign chains on Celestia can achieve sequencer-level confirmations in under a millisecond. Agent micropayments settle at HTTP speed, so the payment never becomes the bottleneck." },
     ],


### PR DESCRIPTION
## What
Copy and content updates from marketing feedback:

- **Proof points (homepage):** brightened the three stat descriptions from `#B0B7C0` to `#E8EBEF` for readability on the dark background
- **TPS figures:** updated `600M+` / `625M` TPS claims to `10M+` across the homepage, Applications, and About pages ("1 Tb/s" figures intentionally left unchanged)
- **Production chains:** `100+` → `25+` (homepage team heading + About meta description)
- **Leadership:** removed Ismail Khoffi; Preston Evans is now CTO, Celestia Labs. Leadership cards now sit three across (≥900px) with the divider and bios aligned via subgrid. About role copy synced with the homepage.

## Why
Copy corrections and team update requested by marketing.
<img width="1785" height="770" alt="Screenshot 2026-07-14 at 18 44 04" src="https://github.com/user-attachments/assets/3efe57b3-cb84-49aa-8329-73732170915f" />
<img width="1473" height="578" alt="Screenshot 2026-07-14 at 18 44 00" src="https://github.com/user-attachments/assets/3970a00c-8a93-47ef-a239-d877c9731b25" />
<img width="1572" height="816" alt="Screenshot 2026-07-14 at 18 43 52" src="https://github.com/user-attachments/assets/56cbce1c-f269-478d-8c75-e443869af8fc" />
<img width="1757" height="801" alt="Screenshot 2026-07-14 at 18 43 46" src="https://github.com/user-attachments/assets/c95122a5-e9e2-47a5-a973-e5e90853d006" />
<img width="1809" height="723" alt="Screenshot 2026-07-14 at 18 43 41" src="https://github.com/user-attachments/assets/85fba768-030c-4dd2-a9a6-32835108365a" />

`npm run verify` passes (lint + typecheck + build). Screenshots below.
