### PR TITLE
ci: drop build-time Cloudflare cache purge

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -44,9 +44,8 @@ jobs:
             docker build --build-arg NEXT_PUBLIC_GHOST_API_URL=$NEXT_PUBLIC_GHOST_API_URL --build-arg NEXT_PUBLIC_GHOST_CONTENT_API_KEY=$NEXT_PUBLIC_GHOST_CONTENT_API_KEY --build-arg MAILCHIMP_API_KEY=$MAILCHIMP_API_KEY --build-arg MAILCHIMP_LIST_ID=$MAILCHIMP_LIST_ID --build-arg MAILCHIMP_SERVER_PREFIX=$MAILCHIMP_SERVER_PREFIX --build-arg NEXT_PUBLIC_RECAPTCHA_SITE_KEY=$NEXT_PUBLIC_RECAPTCHA_SITE_KEY --build-arg RECAPTCHA_SECRET_KEY=$RECAPTCHA_SECRET_KEY --build-arg NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL --build-arg ENV_MODE=$ENV_MODE -t ghcr.io/celestiaorg/celestia.org:latest .
             docker push ghcr.io/celestiaorg/celestia.org:latest
 
-        - name: Purge Cloudflare cache
-          run: |
-            curl -s -X POST "https://api.cloudflare.com/client/v4/zones/dfbcbc30a0faf336d6fb18fb79ffd04e/purge_cache" \
-              -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-              -H "Content-Type: application/json" \
-              --data '{"purge_everything":true}'
+        # Cache purge intentionally removed: purging at build time protects
+        # nothing — the cache-poison window opens during the k8s rolling
+        # restart, which happens minutes to an hour AFTER this workflow. The
+        # infrastructure repo's auto-updater CronJob now purges Cloudflare
+        # right after the rollout converges (digest-aware, post-rollout).


### PR DESCRIPTION
The purge step in this workflow runs right after the image build — but the pods only roll to the new image later (up to an hour, via the hourly auto-updater in the infrastructure repo). The `_next/static` cache-poison window opens during that rolling restart, long after this purge has already run, so the build-time purge protects nothing (verified today: the purge ran at build time and the site still served a blank page after the rollout).

The purge now lives on the other side of the gap: the infrastructure repo's `auto-updater` CronJob is digest-aware and purges Cloudflare immediately after the rollout converges (celestiaorg/infrastructure@86a9941). The `CLOUDFLARE_API_TOKEN` repo secret here can be removed once this merges.