### PR TITLE
chore(deps): batch green Dependabot updates + decline linkinator 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,12 @@ updates:
       # self-hosted Plausible server to support it first.
       - dependency-name: "next-plausible"
         update-types: ["version-update:semver-major"]
+      # linkinator 7 rewrote its CLI and JSON output; scripts/check-links.sh and
+      # scripts/parse-links.js parse the v6 `--format json` shape, so a bare bump
+      # breaks the Check Links job (empty stdout -> "Unexpected end of JSON input").
+      # Adopt in a dedicated PR that ports both scripts to the v7 output.
+      - dependency-name: "linkinator"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,11 +31,11 @@
 				"@types/react": "^19.2.17",
 				"@types/react-dom": "^19.2.3",
 				"copy-webpack-plugin": "^14.0.0",
-				"eslint": "^9.39.4",
+				"eslint": "^9.39.5",
 				"eslint-config-next": "^16.2.10",
 				"husky": "^9.1.7",
 				"linkinator": "^6.1.2",
-				"postcss": "^8.5.16",
+				"postcss": "^8.5.19",
 				"tailwindcss": "^3.4.1",
 				"typescript": "^6.0.3"
 			}
@@ -433,9 +433,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.5",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+			"integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -445,7 +445,7 @@
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.1",
+				"js-yaml": "^4.3.0",
 				"minimatch": "^3.1.5",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -457,9 +457,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.39.4",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+			"version": "9.39.5",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+			"integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3634,9 +3634,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.4",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+			"version": "9.39.5",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+			"integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3645,8 +3645,8 @@
 				"@eslint/config-array": "^0.21.2",
 				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/core": "^0.17.0",
-				"@eslint/eslintrc": "^3.3.5",
-				"@eslint/js": "9.39.4",
+				"@eslint/eslintrc": "^3.3.6",
+				"@eslint/js": "9.39.5",
 				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
@@ -6253,9 +6253,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+			"version": "8.5.19",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+			"integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
 			"funding": [
 				{
 					"type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
 		"copy-webpack-plugin": "^14.0.0",
-		"eslint": "^9.39.4",
+		"eslint": "^9.39.5",
 		"eslint-config-next": "^16.2.10",
 		"husky": "^9.1.7",
 		"linkinator": "^6.1.2",
-		"postcss": "^8.5.16",
+		"postcss": "^8.5.19",
 		"tailwindcss": "^3.4.1",
 		"typescript": "^6.0.3"
 	},


### PR DESCRIPTION
Consolidates this week's Dependabot dependency PRs into one reviewable branch and records the linkinator major as deliberately declined. Supersedes and closes #210, #211, #212.

## What

- **actions/setup-node 6 → 7** (`.github/workflows/link-checker.yml`) — folds in #210. CI action only, no runtime impact.
- **npm minor/patch group** — folds in #211: `eslint` 9.39.4 → 9.39.5, `postcss` 8.5.16 → 8.5.19 (plus transitive `@eslint/*`, `js-yaml` 4.1 → 4.3). Dev-only, same-major patch bumps.
- **Ignore `linkinator` majors** in `dependabot.yml` — declines #212.

## Why decline linkinator 7 (#212)

linkinator 7 rewrote its CLI and JSON output. `scripts/check-links.sh` runs it with `--format json` and pipes to `scripts/parse-links.js`, which parse the **v6** output shape. v7 emits empty/changed stdout, so the Check Links job fails with `Unexpected end of JSON input` (already red on #212). It is **not** a Node-engine issue — v7 needs `node >=20` and we run 22 — and linkinator is a dev/CI-only dep, so the Docker/k8s image is unaffected.

Adopting v7 means porting both scripts to the new output shape + re-testing the crawl. That belongs in a dedicated migration PR, not a bare bump, so the major is added to the ignore list (matching the existing eslint/typescript/tailwindcss/next-plausible pattern) to stop Dependabot re-opening a failing PR every release.

## Verification

`npm run verify` (lint + typecheck + build) passes locally and on pre-push.