### PR TITLE
chore(deps): bump sass to 1.101.7 and pin it to major-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,15 @@ updates:
       # it. Adopt in a dedicated PR that updates the import + verifies the v9 API.
       - dependency-name: "markdown-to-jsx"
         update-types: ["version-update:semver-major"]
+      # sass (dev/build-only Dart Sass) publishes patch/minor releases almost
+      # daily, so it dominated the weekly grouped PR. Unlike the majors above,
+      # here we ignore *minor + patch* and let only majors through — pinning the
+      # 1.x line and cutting the churn. Safe because sass is build-time only (not
+      # in the browser/runtime bundle), and security alerts still fire regardless,
+      # so any real CVE stays visible for a manual bump.
+      - dependency-name: "sass"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"react-dom": "^19.2.8",
 				"react-slick": "^0.31.0",
 				"react-stickynode": "^4.1.1",
-				"sass": "^1.101.6",
+				"sass": "^1.101.7",
 				"slick-carousel": "^1.8.1",
 				"tailwind-merge": "^3.3.0",
 				"tailwind-variants": "^3.2.2"
@@ -6743,9 +6743,9 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.101.6",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.101.6.tgz",
-			"integrity": "sha512-j8qYug9WuX19eU5sxJWQlbR8RYhKgXiOYgGjkJRkcW35c3neWtxPdcUW0saN6Od2L0aqEp0AmH9R/QeAxrffMQ==",
+			"version": "1.101.7",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.101.7.tgz",
+			"integrity": "sha512-cDeUYU0dhwKVbpYg/ppsjyuoddxYhWlJOkRoI7+/iZsaSp7iowWDfm+tL2HcUafedWBDvbf/+hx0QRgKG4JSHA==",
 			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"react-dom": "^19.2.8",
 		"react-slick": "^0.31.0",
 		"react-stickynode": "^4.1.1",
-		"sass": "^1.101.6",
+		"sass": "^1.101.7",
 		"slick-carousel": "^1.8.1",
 		"tailwind-merge": "^3.3.0",
 		"tailwind-variants": "^3.2.2"


### PR DESCRIPTION
Catches `sass` up to the latest patch and stops its weekly churn by pinning it to major-only Dependabot updates. Supersedes #218 (which can be closed once this lands). **Cadence is left untouched — weekly, as before.**

## What

- **sass 1.101.6 → 1.101.7** — the current patch (folds in #218).
- **Pin sass to major-only** in `dependabot.yml`: ignore `sass` minor + patch updates so only a future major (2.x) ever opens a PR. Sits alongside the existing major-decline ignores but is the inverse kind of rule (noise-pin, not a blocked major).

## Why this is safe (not a lingering-vuln risk)

- `sass` is **dev/build-only** (Dart Sass compiles SCSS → CSS at build time). It is **not** in the browser bundle or the production/K8s runtime, so its runtime attack surface is effectively nil.
- Dependabot **security alerts still fire** even for ignored version ranges — only the *automatic version-bump PR* is suppressed. So if sass ever gets a CVE, it stays visible in the Security tab and we do a one-line manual bump.
- Net effect: we lose only the routine patch/minor auto-PRs (the noise), not vulnerability visibility.

This pin is `sass`-specific reasoning — runtime deps like `next`/`react` stay on normal patch updates.

## Verification

`npm run verify` (lint + typecheck + build) passes with sass 1.101.7; `npm ci` confirms the lockfile is in sync (the `libc` fields on `@next/swc-linux-*` preserved for the Alpine/musl Docker build). `dependabot.yml` is config-only.