### PR TITLE
chore(deps): batch build/CI-only patch bumps (docker-login, immutable, fast-uri)

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -32,7 +32,7 @@ jobs:
           uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
         - name: Login to GitHub Container Registry
-          uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4.5.0
+          uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
           with:
             registry: ghcr.io
             username: ${{ github.repository_owner }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4187,9 +4187,9 @@
 			"dev": true
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -4200,7 +4200,8 @@
 					"type": "opencollective",
 					"url": "https://opencollective.com/fastify"
 				}
-			]
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastq": {
 			"version": "1.20.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4789,9 +4789,10 @@
 			}
 		},
 		"node_modules/immutable": {
-			"version": "5.1.7",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.7.tgz",
-			"integrity": "sha512-47Xb+LFbZ/ZIjQMj6Q5J3IfK7PJFuqRdFOC9FpGgRTK6U2dAEVmkR9hp58qU4FpYux5YXpneDwkj2EP6lppzFA=="
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+			"integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+			"license": "MIT"
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.1",


### PR DESCRIPTION
Consolidates this week's Dependabot PRs into one branch. All three are patch bumps to **build/CI-only** dependencies — no runtime, browser, or K8s-image impact, no cascade. Supersedes and closes #220, #221, #222.

## What

- **docker/login-action 4.5.0 → 4.5.1** (`.github/workflows/docker-build-publish.yml`) — folds in #220. SHA-pinned CI action.
- **immutable 5.1.7 → 5.1.9** (lockfile only) — folds in #221. Transitive via `sass` (build-only Dart Sass).
- **fast-uri 3.1.2 → 3.1.4** (lockfile only) — folds in #222. Transitive via `copy-webpack-plugin → schema-utils → ajv` (build-only).

Both npm bumps are same-major patch releases on indirect dev/build deps; neither is a direct dependency, neither touches the production bundle.

## Verification

`npm run verify` (lint + typecheck + build) passes; `npm ci` confirms the lockfile is in sync, with the `libc` fields on `@next/swc-linux-*` preserved for the Alpine/musl Docker build. PR CI does not build, so the local gate is authoritative.