### PR TITLE
content(homepage): new hero copy, proof points, and hero layout

### DIFF
--- a/src/app/(default)/about/page.tsx
+++ b/src/app/(default)/about/page.tsx
@@ -8,7 +8,7 @@ import AboutCTA from "@/components/NewPages/About/AboutCTA";
 const seo = {
 	title: "About",
 	description:
-		"Celestia builds dedicated, high-throughput chains for companies with internet-scale traffic. Meet the team behind the frameworks powering 25+ production chains.",
+		"Celestia builds dedicated, high-throughput chains for companies with internet-scale traffic. Meet the team behind the frameworks powering 25 production chains.",
 	canonical: "https://celestia.org/about/",
 };
 

--- a/src/app/(default)/what-is-tia/page.tsx
+++ b/src/app/(default)/what-is-tia/page.tsx
@@ -56,7 +56,7 @@ const wallets = {
       title: "Cosmostation",
       categories: ["IOS", "Android", "Desktop"],
       image: "/images/app/what-is-tia/cosmostation-icon.jpg",
-      url: "https://cosmostation.io/products/application",
+      url: "https://www.cosmostation.io/",
     },
     {
       title: "Leap",

--- a/src/components/Applications/ApplicationsContent.tsx
+++ b/src/components/Applications/ApplicationsContent.tsx
@@ -114,7 +114,7 @@ const QuoteCard = ({ quote, accentColor }: QuoteCardProps) => (
 // Latency comparison diagram (prototype .uc-latency--card) — amethyst hero column
 const LatencyDiagram = () => {
   const cols = [
-    { value: "1", label: "Bullet", logo: "/images/app/homepage/logo-bullet.svg", dots: 2, gridCols: 2, hero: true },
+    { value: "1.2", label: "Bullet", logo: "/images/app/homepage/logo-bullet.svg", dots: 2, gridCols: 2, hero: true },
     { value: "70", label: "Hyperliquid", logo: "/images/app/homepage/logo-hyperliquid.svg", dots: 63, gridCols: 9, hero: false },
     { value: "400", label: "Solana", logo: "/images/app/homepage/logo-solana.svg", dots: 380, gridCols: 20, hero: false, dense: true },
   ];

--- a/src/components/NewHomepage/HomepageHero.tsx
+++ b/src/components/NewHomepage/HomepageHero.tsx
@@ -2,7 +2,6 @@
 
 import { motion } from "framer-motion";
 import Container from "@/components/Container/Container";
-import Button from "@/components/Button/Button";
 
 // Animation variants
 const fadeUpVariants = {
@@ -92,9 +91,13 @@ const HomepageHero = () => {
       </motion.div>
 
       {/* Content — mobile top anchor 116px (uniform hero anchor, clears the
-          navbar). md+ anchor 164px = prototype's 64px hero pad + 100px content pad. */}
+          navbar). md+: no CTAs anymore, so the text block is vertically centered
+          in the band above the bottom-pinned fibre video. The calc height is the
+          section minus the video: video height = (min(100vw,1520px) − gutters)
+          × 0.2422 (hero-fibre.mp4 is 2560×620). 90px top padding keeps the block
+          clear of the overlay navbar. */}
       <Container size="2xl" className="order-1 md:order-none relative z-10 h-full">
-        <div className="flex flex-col items-center gap-7 md:gap-10 pt-[116px] md:pt-[164px]">
+        <div className="flex flex-col items-center gap-7 md:gap-10 pt-[116px] md:pt-[90px] md:justify-center md:h-[calc(100%-(min(100vw,1520px)-120px)*0.2422)] min-[1200px]:h-[calc(100%-(min(100vw,1520px)-240px)*0.2422)]">
           <div className="flex flex-col items-center gap-7 md:gap-10 text-center px-0 md:px-4">
             <motion.h1
               // Mobile type scale: long-sentence hero title — 26px ≤430, 30px to
@@ -105,52 +108,26 @@ const HomepageHero = () => {
               animate="visible"
               custom={0.1}
             >
-              A custom blockchain.
+              Escape Velocity for
               <br />
-              Built for your business.
-              <br />
-              Owned by you.
+              Onchain Economy
             </motion.h1>
 
             <motion.p
               // Mobile type scale: hero lead — 17px ≤430, 18px to 768
-              className="font-nuberNext font-medium text-[17px] min-[431px]:text-[18px] leading-[1.4] max-md:text-pretty md:text-[24px] md:leading-[1.25] tracking-[-0.01em] text-white/45 max-w-[720px]"
+              className="font-nuberNext font-normal text-[17px] min-[431px]:text-[18px] leading-[1.4] max-md:text-pretty md:text-[18px] tracking-[-0.01em] text-[#E8EBEF] max-w-[720px]"
               variants={fadeUpVariants}
               initial="hidden"
               animate="visible"
               custom={0.25}
             >
-              Celestia designs and ships custom, high-throughput chains for the
-              world&apos;s most ambitious enterprises.
+              Celestia is the Layer 1 blockchain powering the world&apos;s
+              fastest exchanges and agentic payments platforms. We build custom
+              solutions at the bleeding edge of performance for internet-scale
+              onchain applications.
             </motion.p>
           </div>
 
-          {/* CTAs — mobile: stacked + centered, 18px gap; secondary collapses to
-              a plain text link with a chevron arrowhead (prototype mobile) */}
-          <motion.div
-            className="flex flex-col md:flex-row items-center gap-[18px] md:gap-4"
-            variants={fadeUpVariants}
-            initial="hidden"
-            animate="visible"
-            custom={0.4}
-          >
-            <Button href="/build-with-us/" variant="pill-primary" size="pill-md">
-              Build with us
-            </Button>
-            <Button
-              href="/applications/"
-              variant="pill-outline"
-              size="pill-md"
-              className="!text-white border-white/30 hover:border-white/50 max-md:border-0 max-md:bg-transparent max-md:px-0 max-md:py-1 max-md:text-base max-md:hover:opacity-70"
-            >
-              See what&apos;s possible on Celestia
-              {/* arrowhead chevron (no shaft) — mobile text-link affordance */}
-              <span
-                aria-hidden="true"
-                className="md:hidden inline-block h-[7px] w-[7px] rotate-45 border-r-[1.8px] border-t-[1.8px] border-current"
-              />
-            </Button>
-          </motion.div>
         </div>
       </Container>
     </section>

--- a/src/components/NewHomepage/ProofPoints.tsx
+++ b/src/components/NewHomepage/ProofPoints.tsx
@@ -5,16 +5,16 @@ import Button from "@/components/Button/Button";
 
 const stats = [
 	{
-		number: "25+",
-		label: "Production chains built and launched by the team.",
+		number: "1.2ms Latency",
+		label: "Industry-leading transaction confirmation times.",
 	},
 	{
 		number: "625M+ TPS",
 		label: "Potential throughput of blockchains built on Celestia.",
 	},
 	{
-		number: "< $0.0001",
-		label: "Cost per transaction.",
+		number: "25 Chains Shipped",
+		label: "Unmatched blockchain engineering experience.",
 	},
 ];
 
@@ -43,7 +43,7 @@ const ProofPoints = () => {
 					{stats.map((stat, index) => (
 						<div key={stat.number} className="contents">
 							<div className="flex flex-col items-center gap-3 text-center min-[900px]:flex-1">
-								<span className="flex items-center justify-center min-h-[56px] whitespace-nowrap font-nuberNextWide font-semibold text-[32px] min-[900px]:text-[56px] leading-none tracking-[-0.02em] text-[#FDFCFF]">
+								<span className="flex items-center justify-center min-h-[56px] whitespace-nowrap font-nuberNextWide font-semibold text-[32px] min-[900px]:text-[clamp(23px,2.55vw,42px)] leading-none tracking-[-0.02em] text-[#FDFCFF]">
 									{stat.number}
 								</span>
 								<span className="font-nuberNext font-normal text-[16px] leading-[1.5] tracking-[-0.01em] text-[#E8EBEF] max-w-[280px]">

--- a/src/components/NewHomepage/TeamSection.tsx
+++ b/src/components/NewHomepage/TeamSection.tsx
@@ -75,7 +75,7 @@ const TeamCard = ({ name, role, bio }: TeamCardProps) => (
 );
 
 /**
- * TeamSection — "The team that built the frameworks behind 25+ production
+ * TeamSection — "The team that built the frameworks behind 25 production
  * chains." Ported from the prototype's .home-team section: a 3-column grid of
  * text-only member cards (dark→light on hover) and a "Meet the full team" CTA.
  */
@@ -90,7 +90,7 @@ const TeamSection = () => {
 				viewport={{ once: true, margin: "-50px" }}
 				variants={fadeUp}
 			>
-				The team that built the frameworks behind 25+ production chains.
+				The team that built the frameworks behind 25 production chains.
 			</motion.h2>
 
 			<motion.div

--- a/src/components/NewHomepage/UseCasesSection.tsx
+++ b/src/components/NewHomepage/UseCasesSection.tsx
@@ -207,7 +207,7 @@ const ExchangesVisual = () => (
 	<div className='flex flex-col justify-end gap-4 px-6 md:px-8 pb-7 flex-1 max-md:min-h-[248px]'>
 		<div className='flex gap-1.5 sm:gap-2.5 flex-1 items-stretch'>
 			<LatencyCol
-				value='1'
+				value='1.2'
 				hero
 				logo='/images/app/homepage/logo-bullet.svg'
 				logoAlt='Bullet'

--- a/src/components/NewPages/BuildWithUs/BwuWhy.tsx
+++ b/src/components/NewPages/BuildWithUs/BwuWhy.tsx
@@ -10,8 +10,8 @@ const items = [
 		body: "Celestia's founder, Mustafa Al-Bassam, co-authored the data availability research underpinning Ethereum's scaling roadmap. The same engineering team designs and ships every Celestia chain.",
 	},
 	{
-		title: "25+ Production Chains Built and Launched by the Team",
-		body: "Celestia engineers have shipped 25+ production chains across exchanges, payment networks, and onchain financial markets. Real chains, in production, at scale.",
+		title: "25 Production Chains Built and Launched by the Team",
+		body: "Celestia engineers have shipped 25 production chains across exchanges, payment networks, and onchain financial markets. Real chains, in production, at scale.",
 	},
 	{
 		title: "Dedicated Throughput, Owned by You",

--- a/src/data/about/team.ts
+++ b/src/data/about/team.ts
@@ -2,7 +2,7 @@
 
 export const aboutStats = [
 	{
-		number: "25+",
+		number: "25",
 		label: "Production chains built and launched by the team.",
 	},
 	{

--- a/src/data/build/frameworks.ts
+++ b/src/data/build/frameworks.ts
@@ -7,7 +7,7 @@ export const frameworks = [
     description:
       "Build a blockchain with EVM smart contracts and guaranteed interop with all Cosmos rollups.",
     image: "/images/app/build/logo-abc-stack.png",
-    url: "https://abundance.xyz/",
+    url: "https://abundance.build/",
     trackEvent: ANALYTICS_EVENTS.PORTAL_FRAMEWORK_ABC_STACK,
   },
   {

--- a/src/data/ecosystem/ecosystemExplorer.ts
+++ b/src/data/ecosystem/ecosystemExplorer.ts
@@ -872,7 +872,7 @@ export const ecosystemData = {
       title: "ABC Stack",
       description: "The first Gigagas L1 stack.",
       image: "/images/app/ecosystem/abc.png",
-      url: "https://abundance.xyz/",
+      url: "https://abundance.build/",
       chainIcon: "",
       chainIconLink: "",
       categories: "dev-tooling",


### PR DESCRIPTION
## What

- Hero title: "Escape Velocity for / Onchain Economy" (two lines)
- New hero paragraph; set 18px regular in #E8EBEF to match stat labels
- Removed the hero CTAs and re-centred the text block in the band above the fibre video
- Proof points now read "1.2ms Latency" / "625M+ TPS" / "25 Chains Shipped" (words in the numeral, fluid single-line sizing)
- Latency comparisons: Bullet 1 ms -> 1.2 ms (homepage + applications)
- Chains shipped: 25+ -> 25 site-wide (team section, about, build-with-us)

## Why

Homepage copy refresh for the new positioning; values aligned across pages.

Verified with `npm run verify` (lint + typecheck + build) and checked in the browser at desktop and mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)